### PR TITLE
Including Dockerfile to allow execute the app inside a container.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.7-slim
+
+LABEL mantainer="hugoperlin"
+
+ADD . /opt/app
+
+ADD start.sh /
+
+RUN chmod +x /start.sh
+
+WORKDIR /opt/app
+
+RUN pip3 install -r requirements.txt
+
+EXPOSE 8000
+
+CMD ["/start.sh"] 

--- a/app.py
+++ b/app.py
@@ -6,6 +6,9 @@ import pickle
 app = Flask(__name__)
 model = pickle.load(open('model.pkl', 'rb'))
 
+#for gunnicorn
+application=app
+
 
 @app.route('/dataset',methods=['GET'])
 def get_dataset():
@@ -23,4 +26,4 @@ def results():
     return jsonify(output)
 
 if __name__ == "__main__":
-    app.run(debug=True,port=8000)
+    app.run(debug=True,host="0.0.0.0",port=8000)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+
+  web:
+    image: sales-forecast-service
+    build:
+      context: .
+    ports:
+      - "8001:8000"
+  
+
+    
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scikit-learn
 numpy
 pandas
 matplotlib
+gunicorn

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+cd /opt/app
+python model.py
+gunicorn -b 0.0.0.0:8000 app


### PR DESCRIPTION
- Created a Dockerfile based on python:3.7-slim. This version allows easily install the requirements
- Included gunnicorn to serve the application
- To gunnicorn works, it was needed to add a variable application inside app.py
- The container staturp command is "/start.sh", which will execute the _python model.py_ and gunnicorn