### PR TITLE
Containerize the microservice using Docker #1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.7-slim
+RUN apt-get update
+WORKDIR /app/
+COPY requirements.txt /app/
+RUN pip install -r requirements.txt
+COPY app.py model.py model.pkl sales.csv /app/
+EXPOSE 8000
+ENTRYPOINT [ "python" ]
+CMD [ "app.py" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.7"
+services:
+  app:
+    container_name: sales-forecast-service
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
Add Docker file and docker-compose.yml.

Tried using Python 3.7-alpine as the base image but it had errors,
so use the image Python 3.7-slim instead.

Command-line Usage:

Run container:
$ docker-compose up -d

Run container and rebuild image:
$ docker-compose up --build

Stop container:
$ docker-compose down

For Windows Docker system, you will have to amend the app.py as follows:

Old:
    app.run(debug=True,port=8000)

New:
    app.run(debug=True,host='0.0.0.0',port=8000)